### PR TITLE
Add TypeScript API helper for processes

### DIFF
--- a/frontend/src/api/processes.ts
+++ b/frontend/src/api/processes.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import { Process } from '../types';
+
+const api = axios.create({ baseURL: 'http://localhost:8000/api' });
+
+export async function getProcesses(): Promise<Process[]> {
+  const { data } = await api.get<Process[]>('/processes');
+  return data;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,3 @@
+export enum Applicability { MZ="MZ", WP="WP", NZ="NZ" }
+export interface Process { id:number; name:string; category_id:number; applicability:Applicability; }
+


### PR DESCRIPTION
## Summary
- add axios-based API helper to fetch processes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853180ab380833195fe2fd26b372773