### PR TITLE
Add basic React form with process controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import GeneralForm from './components/GeneralForm';
+
+const App: React.FC = () => {
+  return (
+    <div>
+      <h1>General Form</h1>
+      <GeneralForm />
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/components/GeneralForm.tsx
+++ b/frontend/src/components/GeneralForm.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { getProcesses } from '../api/processes';
+import { Applicability, Process } from '../types';
+
+export type FormValues = { [id: string]: Applicability };
+
+const GeneralForm: React.FC = () => {
+  const { control, handleSubmit } = useForm<FormValues>();
+  const [processes, setProcesses] = useState<Process[]>([]);
+
+  useEffect(() => {
+    getProcesses()
+      .then(setProcesses)
+      .catch((err) => console.error('Failed to fetch processes', err));
+  }, []);
+
+  const onSubmit = (data: FormValues) => {
+    console.log('Selected values', data);
+    return data;
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      {processes.map((process) => (
+        <div key={process.id} style={{ marginBottom: '1rem' }}>
+          <label htmlFor={`process-${process.id}`}>{process.name}</label>
+          <Controller
+            name={String(process.id)}
+            control={control}
+            defaultValue={process.applicability}
+            render={({ field }) => (
+              <select {...field} id={`process-${process.id}`}>
+                {Object.values(Applicability).map((app) => (
+                  <option key={app} value={app}>
+                    {app}
+                  </option>
+                ))}
+              </select>
+            )}
+          />
+        </div>
+      ))}
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+export default GeneralForm;


### PR DESCRIPTION
## Summary
- implement `GeneralForm` using React Hook Form
- fetch processes on mount
- add select per process with MZ/WP/NZ options
- simple `App` wrapper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685319b4a9448331887f68673fb7d29b